### PR TITLE
Introduce redis container in sidecar for use with Sidekiq

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
 	},
 
 	"containerEnv": {
-		"CAPYBARA_SERVER_PORT": "45678"
+		"CAPYBARA_SERVER_PORT": "45678",
+		"JOBS_REDIS_URL": "redis://redis:6379/1"
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -27,3 +27,10 @@ services:
     image: seleniarm/standalone-chromium
     networks:
       - default
+
+  redis:
+    image: redis:7.2
+    networks:
+      - default
+    ports:
+      - 6379:6379

--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,8 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem "sidekiq"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
     prism (0.17.1)
     psych (5.1.0)
       stringio
@@ -196,6 +198,8 @@ GEM
     rake (13.0.6)
     rdoc (6.5.0)
       psych (>= 4.0.0)
+    redis-client (0.19.1)
+      connection_pool
     regexp_parser (2.8.1)
     reline (0.3.8)
       io-console (~> 0.5)
@@ -214,6 +218,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.2.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
     sorbet-runtime (0.5.11144)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -223,6 +232,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.6-aarch64-linux)
+    sqlite3 (1.6.6-arm64-darwin)
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     stringio (3.0.8)
@@ -250,6 +260,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   bootsnap
@@ -262,6 +273,7 @@ DEPENDENCIES
   rails!
   ruby-lsp-rails
   selenium-webdriver
+  sidekiq
   sprockets-rails
   sqlite3 (~> 1.4)
   stimulus-rails

--- a/app/jobs/posts_archive_job.rb
+++ b/app/jobs/posts_archive_job.rb
@@ -1,0 +1,7 @@
+class PostsArchiveJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    # Do something later
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,7 @@ module MyNewApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,9 @@
+redis_url = ENV.fetch("JOBS_REDIS_URL", "redis://localhost:6379/1")
+
+Sidekiq.configure_server do |config|
+  config.redis = { url: redis_url }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: redis_url }
+end

--- a/test/jobs/posts_archive_job_test.rb
+++ b/test/jobs/posts_archive_job_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+require "sidekiq/testing"
+
+class PostsArchiveJobTest < ActiveSupport::TestCase
+  test "the truth" do
+    Sidekiq::Testing.disable! do
+      assert_nothing_raised do
+        PostsArchiveJob.perform_later
+      end
+    end
+  end
+end


### PR DESCRIPTION
Introduce redis container in sidecar for use with Sidekiq

- Create a redis sidecar
- Add the sidekiq gem
- Configure sidekiq server and client to use the host `redis` instead of `localhost`

I verified this is working in the console, however I am having trouble testing it since redis is not used in tests by default. `Sidekiq::Testing.disable!` should "disable" the mocking in tests, and use redis, but when I do that I still can enqueue jobs when redis is not properly configured so I get false positive tests. I will keep looking into it..