### PR TITLE
Fix workspaceFolder so it works in VSCode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"name": "Ruby",
 	"dockerComposeFile": "docker-compose.yml",
 	"service": "rails-app",
-	"workspaceFolder": "/workspace",
+	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: .devcontainer/Dockerfile
 
     volumes:
-      - ..:/workspaces:cached
+      - ../..:/workspaces:cached
 
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity


### PR DESCRIPTION
As we discussed, I changed this setup of `workspaceFolder` so that the container opens in vscode in `workspaces/my_new_app` like the rails container does.