### PR TITLE
Demonstrate ActionCable and Turbo functionality

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,8 @@
 
 	"containerEnv": {
 		"CAPYBARA_SERVER_PORT": "45678",
-		"JOBS_REDIS_URL": "redis://redis:6379/1"
+		"JOBS_REDIS_URL": "redis://redis:6379/1",
+		"CABLE_REDIS_URL": "redis://redis:6379/1"
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "stimulus-rails"
 gem "jbuilder"
 
 # Use Redis adapter to run Action Cable in production
-# gem "redis", ">= 4.0.1"
+gem "redis", ">= 4.0.1"
 
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.5)
     minitest (5.20.0)
     msgpack (1.7.2)
     mutex_m (0.1.2)
@@ -169,6 +170,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.15.4-arm64-darwin)
@@ -198,6 +202,7 @@ GEM
     rake (13.0.6)
     rdoc (6.5.0)
       psych (>= 4.0.0)
+    redis (5.0.7)
     redis-client (0.19.1)
       connection_pool
     regexp_parser (2.8.1)
@@ -231,6 +236,8 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.6)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (1.6.6-aarch64-linux)
     sqlite3 (1.6.6-arm64-darwin)
     stimulus-rails (1.2.2)
@@ -271,6 +278,7 @@ DEPENDENCIES
   jbuilder
   puma (>= 5.0)
   rails!
+  redis (>= 4.0.1)
   ruby-lsp-rails
   selenium-webdriver
   sidekiq

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link_tree ../../javascript .js
+//= link_tree ../../../vendor/javascript .js

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,2 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,3 @@
 class Post < ApplicationRecord
+  after_create_commit { broadcast_append_to "posts" }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,7 @@
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags %>
   </head>
 
   <body>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,6 +2,7 @@
 
 <h1>Posts</h1>
 
+<%= turbo_stream_from "posts" %>
 <div id="posts">
   <% @posts.each do |post| %>
     <%= render post %>

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/application"
+require "importmap/commands"

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,10 +1,11 @@
 development:
-  adapter: async
+  adapter: redis
+  url: <%= ENV.fetch("CABLE_REDIS_URL") { "redis://localhost:6379/1" } %>
 
 test:
   adapter: test
 
 production:
   adapter: redis
-  url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
+  url: <%= ENV.fetch("CABLE_REDIS_URL") { "redis://localhost:6379/1" } %>
   channel_prefix: my_new_app_production

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,4 @@
+# Pin npm packages by running ./bin/importmap
+
+pin "application", preload: true
+pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true


### PR DESCRIPTION
Demonstrating ActionCable and Turbo can function in the dev container.

The steps I followed are: 
- Introduce import maps (`bin/rails importmap:install`). It's required for turbo.
- Introduce turbo (`bin/rails turbo:install`). It's much easier out of the box to setup the websocket that writing your own.
- Broadcast when new posts are created with `broadcast_append_to` in a commit hook
- Subscribe to posts broadcast from the posts index with `turbo_stream_from`
- Introduce redis in the container (basically just copying the work in https://github.com/Shopify/my_new_app/pull/6)

Interestingly, when you do `turbo:install` it changes the action cable adapter in `cable.yml` for `development` to the redis adapter. But switching it back to `async` also works fine (I tested both, locally and in container)... so I am not sure why it does this. Anyway, I used redis.

https://github.com/Shopify/my_new_app/assets/39735028/0a150b26-5d5e-4abf-98a6-c92332ce06e2


