### PR TITLE
Debug config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "ruby_lsp",
+            "name": "Debug test",
+            "request": "launch",
+            "program": "bin/rails test ${relativeFile}"
+        },
+        {
+            "type": "ruby_lsp",
+            "name": "Debug runner",
+            "request": "launch",
+            "program": "bin/rails runner ${relativeFile}"
+        },
+        {
+            "type": "ruby_lsp",
+            "name": "Attach debugger",
+            "request": "attach"
+        }
+    ]
+}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.15.4-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.4-arm64-darwin)
+      racc (~> 1.4)
     prism (0.17.1)
     psych (5.1.0)
       stringio
@@ -223,6 +225,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.6-aarch64-linux)
+    sqlite3 (1.6.6-arm64-darwin)
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     stringio (3.0.8)
@@ -250,6 +253,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
Introduce some debugger configs in `.vscode/launch.json`. 

Vscode debugger can't work with rails console or server, instead you have to attach to those process when they're running.

So I created configs for `rails test` and `rails runner` and left the existing config for `attach`.